### PR TITLE
Use Gunicorn server in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,8 @@ RUN mkdir -p app/static/voices app/static/output
 # Expose the port the app runs on
 EXPOSE 5000
 
-# Command to run the application
-CMD ["python", "run.py"]
+# Set required environment variables
+ENV COQUI_TOS_AGREED=1
+
+# Command to run the application with Gunicorn
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "run:app"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A web application that generates hypnosis audio from text using XTTS-v2 text-to-
    docker build -t hypno-ai .
    ```
 
-2. Run the container:
+2. Run the container (it uses Gunicorn for production):
    ```
    docker run -p 5000:5000 hypno-ai
    ```
@@ -87,6 +87,8 @@ A web application that generates hypnosis audio from text using XTTS-v2 text-to-
    ```
    docker-compose up -d
    ```
+
+   The container runs the Flask app with Gunicorn.
 
 2. Access the application at `http://localhost:5000`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,5 @@ services:
       - ./app/static/output:/app/app/static/output
     environment:
       - FLASK_ENV=production
+      - COQUI_TOS_AGREED=1
     restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.1
 Werkzeug==3.1.3
 pydub==0.25.1
 coqui-tts==0.26.2
+gunicorn==21.2.0

--- a/run.py
+++ b/run.py
@@ -7,4 +7,4 @@ app = create_app()
 if __name__ == '__main__':
     # In production, bind to all interfaces and disable debug mode
     os.environ["COQUI_TOS_AGREED"] = "1"
-    app.run(host='0.0.0.0', port=5000, debug=False)
+    app.run(host='127.0.0.1', port=5000, debug=False)


### PR DESCRIPTION
## Summary
- serve the Flask app with Gunicorn in the Docker image
- set `COQUI_TOS_AGREED` env var for Docker
- update example `docker-compose.yml`
- default dev server binds to `127.0.0.1`
- document the Gunicorn-based Docker setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686c25b4c4c0833387278cf08d0ab962